### PR TITLE
Fix bug plus add to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # InputArgs
-A sublime text plugin to send custom input arguments when building using 'ctrl + b'. View a program output with custom arguments from within sublime text.
-
+A sublime text plugin to send custom input arguments when building using 'ctrl + b'. View a program output with custom arguments from within sublime text (see http://stackoverflow.com/questions/16490889/build-and-run-with-arguments-in-sublime-text-2 for discussion and alternatives).
 
 ##Installing
 
@@ -34,4 +33,17 @@ Standard sublime text build system commands.
 
 Use "ctrl+b" to run the build system and an input dialog will ask for arguments.
 
-New Build Systems can be added through "Tools>Build System>New Build System".
+New build systems can be added through "Tools>Build System>New Build System".
+
+If you'd rather not override your build system and instead would prefer to customize it, you can use the `target` option and change the name of the plugin command from `ExecCommand`; e.g., `InputArgsCommand` would match the target option `input_args` as shown in the below example:
+
+### Example build system
+```
+{
+  "shell_cmd" : ["make $file_base_name && ./$file_base_name"],
+  "selector" : "source.c",
+  "shell": true,
+  "target": "input_args",
+  "working_dir" : "$file_path",
+}
+```

--- a/exec.py
+++ b/exec.py
@@ -137,7 +137,8 @@ class ExecCommand(sublime_plugin.WindowCommand, ProcessListener):
             word_wrap = True, syntax = "Packages/Text/Plain text.tmLanguage",
             # Catches "path" and "shell"
             **kwargs):
-        self.sl = kwargs
+
+        shell_cmd = ''.join(shell_cmd)
         # clear the text_queue
         self.text_queue_lock.acquire()
         self.truth = False
@@ -241,7 +242,7 @@ class ExecCommand(sublime_plugin.WindowCommand, ProcessListener):
         try:
             # Forward kwargs to AsyncProcess
             
-            self.proc = AsyncProcess(cmd, shell_cmd, merged_env, self, self.sl)
+            self.proc = AsyncProcess(cmd, shell_cmd, merged_env, self)
             
             self.text_queue_lock.acquire()
             try:


### PR DESCRIPTION
The fifth argument for AsyncProcess is a string (`path`) and the sl being passed in is a dict with additional kwargs from the build process (e.g., in my case it just says { "shell": true }, which throws a `str expected, not dict` error.

Passing in this path doesn't seem to be necessary anyway.

Also added an example build file because I had accidentally put `cmd` rather than `shell_cmd`.

Do you think you might put this on PackageControl? If not, do you mind if I do?