### PR TITLE
Fix async kwargs

### DIFF
--- a/exec.py
+++ b/exec.py
@@ -257,7 +257,7 @@ class ExecCommand(sublime_plugin.WindowCommand, ProcessListener):
         try:
             # Forward kwargs to AsyncProcess
             
-            self.proc = AsyncProcess(cmd, shell_cmd, merged_env, self, self.sl)
+            self.proc = AsyncProcess(cmd, shell_cmd, merged_env, self, *self.sl)
             
             self.text_queue_lock.acquire()
             try:

--- a/exec.py
+++ b/exec.py
@@ -257,7 +257,7 @@ class ExecCommand(sublime_plugin.WindowCommand, ProcessListener):
         try:
             # Forward kwargs to AsyncProcess
             
-            self.proc = AsyncProcess(cmd, shell_cmd, merged_env, self, *self.sl)
+            self.proc = AsyncProcess(cmd, shell_cmd, merged_env, self, **self.sl)
             
             self.text_queue_lock.acquire()
             try:


### PR DESCRIPTION
This proposed fix addresses issue #10
 
self.sl is a dictionary that is given as argument to AsyncProcess,
but it ends up mapped to `path` argument, instead of I guess being
used as a keyword argument.

AsyncProcess(..., path="", shell=False) ends up called as path={shell:True} on my environment, hence the reported error message.

I might not be the proper fix.